### PR TITLE
Added HDF file for the test TARDIS full

### DIFF
--- a/tardis/tests/test_tardis_full/test_transport_simple/TestTransportSimple.h5
+++ b/tardis/tests/test_tardis_full/test_transport_simple/TestTransportSimple.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59bf009ba154c3a5aaf2c6f30a00b980dc31440ff99ece6c89843f6da68e4204
+size 77279072


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

> Extracted the transport-state group and data from the HDF and stored in a new h5 file. This HDF is for test TARDIS full.
>
> This regression data is used in the pull request: https://github.com/tardis-sn/tardis/pull/2611.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

> N/A

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method: used the h5 tools.
- [ ] My changes can't be tested (explain why)

In tardis-refdata repository:

I copied the transport-state group and stored in a new h5 file.
```bash
h5copy \
 --input unit_test_data.h5 \
 --source "/test_transport_simple/transport_state" \
 --output TestTransportSimple.h5\
 --destination "/transport_state"
```

Validate that the original and the copy are the same.
```bash
h5diff \
 -r \
 unit_test_data.h5 \
 TestTransportSimple.h5 \
 /test_transport_simple/transport_state/j_blue_estimator \
 /transport_state/j_blue_estimator
```

Moved the generated file TestTransportSimple.h5 to the repository tardis-regression-data.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
