### PR TITLE
Added the regression tests for the weighted packet source

### DIFF
--- a/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_attributes.h5
+++ b/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_attributes.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30df2dcf15bbf44e5da04f3b6834cf8a1ef02ff7a701d993eb0f2ffffe8f6631
+size 7032

--- a/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_energies.npy
+++ b/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_energies.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7719b4f3c793b2ca4bf15b14925d24658610c2e926a746d2f0289848055c940c
+size 928

--- a/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_mus.npy
+++ b/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_mus.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e483fa18fa78cbd3427bc5376ad728ce92a3744072bbd79dfd36bd97b1ad502f
+size 928

--- a/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_nus.npy
+++ b/tardis/transport/montecarlo/tests/test_weighted_packet_source/test_black_body_weighted_source/test_bb_nus.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de2a9f129ec1f5d53ff81eb6c8f76285fd17f5cd4dfc962d1ac4dfaf84ae070b
+size 928


### PR DESCRIPTION
### :pencil: Weighted Packet Source regression tests

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Added in the regression tests for the weighted packet source following the same structure as the simple blackbody source


How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
