### PR TITLE
Update track boundary regression data

### DIFF
--- a/tardis/transport/montecarlo/tests/test_rpacket_tracker/test_boundary_interactions.npy
+++ b/tardis/transport/montecarlo/tests/test_rpacket_tracker/test_boundary_interactions.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e0649bb2bec3183a39eca2514489d68937b59f2a567ba02e726b9b92c9c414a
-size 18432192
+oid sha256:8690a4cfe131e60ac2b63adbc23a6767fefb7ee1961db9ba041a7502feae2767
+size 6144192

--- a/tardis/transport/montecarlo/tests/test_rpacket_tracker/test_boundary_interactions.npy
+++ b/tardis/transport/montecarlo/tests/test_rpacket_tracker/test_boundary_interactions.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0649bb2bec3183a39eca2514489d68937b59f2a567ba02e726b9b92c9c414a
+size 18432192


### PR DESCRIPTION
### :pencil: Description

After reviews on tardis PR https://github.com/tardis-sn/tardis/pull/2736 the structure of the regression got changed. So, here is the updated regression data.

