### PR TITLE
Move `TestSpectrumSolver.h5` to proper folder

### DIFF
--- a/tardis/spectrum/tests/test_spectrum_solver/test_spectrum_solver/TestSpectrumSolver.h5
+++ b/tardis/spectrum/tests/test_spectrum_solver/test_spectrum_solver/TestSpectrumSolver.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00a04309dc492dca1a29697c0892b4942d2e27ef97e2c48752e45c1ff4a47c91
+size 137568427

--- a/test_spectrum_solver/test_spectrum_solver/TestSpectrumSolver.h5
+++ b/test_spectrum_solver/test_spectrum_solver/TestSpectrumSolver.h5
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5286b971cf158a004a2b80ecae210ec02dc38946678c6c438f0eca095e7ff52
-size 136514051


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` :vertical_traffic_light: `testing` 

[tardis-sn/tardis@`2706faa` (#2808)](https://github.com/tardis-sn/tardis/pull/2808/commits/2706faa2b7e6eca1ed08b98f72a036655cb2e269) turns the spectrum tests into a module which corrects the path of the HDF file.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
