### PR TITLE
New data from Carsus with raw Chianti collision data

### DIFF
--- a/atom_data/new_kurucz_cd23_chianti_H_He.h5
+++ b/atom_data/new_kurucz_cd23_chianti_H_He.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b39fc094122bfd1f838baebbd11c3b0f9e1ecc8d7586f1c8b7e90602c7f7b783
+size 77922779


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

This data will eventually replace the default TARDIS atom data once I work out why the UUID and MD5 hashes aren't saving at the top of the tree. Required for https://github.com/tardis-sn/tardis/pull/2770 tests to pass.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
