### PR TITLE
Adds Si data with raw Chianti collisional data

### DIFF
--- a/atom_data/kurucz_cd23_chianti_Si.h5
+++ b/atom_data/kurucz_cd23_chianti_Si.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ee35626162f1537dc09fd9e329ef8ffb102f2cced8bcc7f9e0abc8e9fe9c34d
+size 246314627

--- a/atom_data/kurucz_cd23_chianti_Si.h5
+++ b/atom_data/kurucz_cd23_chianti_Si.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ee35626162f1537dc09fd9e329ef8ffb102f2cced8bcc7f9e0abc8e9fe9c34d
+oid sha256:ba740674882ac4e5a3687d0b140008e4425bd5077130d4037eddcd4f578e346f
 size 246314627

--- a/tardis/plasma/equilibrium/tests/test_level_populations/test_level_population_solver/test_solve__collisional_rate_solver0-radiative_transitions0__.h5
+++ b/tardis/plasma/equilibrium/tests/test_level_populations/test_level_population_solver/test_solve__collisional_rate_solver0-radiative_transitions0__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5605638ba5786bbe11f05074167674d869fd1c9c464316d1235b5298a5b5c089
+size 6479684

--- a/tardis/plasma/equilibrium/tests/test_rate_matrix/test_rate_matrix_solver__collisional_rate_solver0-radiative_transitions0__.h5
+++ b/tardis/plasma/equilibrium/tests/test_rate_matrix/test_rate_matrix_solver__collisional_rate_solver0-radiative_transitions0__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2f7f695f5df0fc444f7143702e6c006ca800e269fc65a45c8b2e5d11832807d
+size 3300168


### PR DESCRIPTION
### :pencil: Description

**Type:**  :rocket: `feature` 

This adds new atomic data including raw Chianti collisional data for silicon. This is intended to work with PR https://github.com/tardis-sn/tardis/pull/2865
