### PR TITLE
Call LFS-cache workflow from regression data repo

### DIFF
--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -12,6 +12,8 @@ jobs:
   trigger-tardis-cache:
     runs-on: ubuntu-latest
     steps:
+      # Uses the GitHub API for dispatching workflows
+      # see https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
       - name: Trigger LFS Cache Workflow
         run: |
           curl -L \

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -1,0 +1,19 @@
+name: Trigger Tardis LFS Cache
+
+on:
+  workflow_dispatch:  # Allows manual triggering
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  trigger-tardis-cache:
+    uses: tardis-sn/tardis/.github/workflows/lfs-cache.yml@main
+    permissions:
+      contents: read
+    secrets:
+      token: ${{ secrets.BOT_TOKEN }}  # Personal Access Token with workflow permissions
+    with:
+      atom-data-sparse: true  # Set to true to only download H_He data
+      allow_lfs_pull: false    # Allow LFS pull operations when cache miss occurs 

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:  # Allows manual triggering
   push:
     branches: [ main ]
+    paths:
+      - 'tardis/**'
 
 
 jobs:

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -20,7 +20,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/tardis-sn/tardis/actions/workflows/lfs-cache.yml/dispatches \
             -d '{
-              "ref": "master",
+              "ref": "dispatch_lfs_cache",
               "inputs": {
                 "atom-data-sparse": "true",
                 "allow_lfs_pull": "false"

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -3,9 +3,8 @@ name: Trigger Tardis LFS Cache
 on:
   workflow_dispatch:  # Allows manual triggering
   push:
-    branches: '*'
-  pull_request:
     branches: [ main ]
+
 
 jobs:
   trigger-tardis-cache:
@@ -20,9 +19,24 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/tardis-sn/tardis/actions/workflows/lfs-cache.yml/dispatches \
             -d '{
-              "ref": "dispatch_lfs_cache",
+              "ref": "master",
               "inputs": {
-                "atom-data-sparse": "true",
-                "allow_lfs_pull": "false"
+                "atom-data-sparse": "false",
+                "allow_lfs_pull": "true"
               }
             }' 
+      - name: Trigger LFS Cache Workflow Atom Data Sparse
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/tardis-sn/tardis/actions/workflows/lfs-cache.yml/dispatches \
+          -d '{
+            "ref": "master",
+            "inputs": {
+              "atom-data-sparse": "true",
+              "allow_lfs_pull": "true"
+            }
+          }' 

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -3,7 +3,7 @@ name: Trigger Tardis LFS Cache
 on:
   workflow_dispatch:  # Allows manual triggering
   push:
-    branches: [ main ]
+    branches: '*'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -9,11 +9,20 @@ on:
 
 jobs:
   trigger-tardis-cache:
-    uses: tardis-sn/tardis/.github/workflows/lfs-cache.yml@main
-    permissions:
-      contents: read
-    secrets:
-      token: ${{ secrets.BOT_TOKEN }}  # Personal Access Token with workflow permissions
-    with:
-      atom-data-sparse: true  # Set to true to only download H_He data
-      allow_lfs_pull: false    # Allow LFS pull operations when cache miss occurs 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger LFS Cache Workflow
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/tardis-sn/tardis/actions/workflows/lfs-cache.yml/dispatches \
+            -d '{
+              "ref": "master",
+              "inputs": {
+                "atom-data-sparse": "true",
+                "allow_lfs_pull": "false"
+              }
+            }' 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`


https://github.com/tardis-sn/tardis-regression-data/actions/runs/13587488417/job/37986014874
https://github.com/tardis-sn/tardis/actions/runs/13587619355/job/37986020302

Allows generating LFS cache from pushes to the tardis-regression-data repository main branch.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
