### PR TITLE
regression data add for composition

### DIFF
--- a/test_composition/test_calculate_cell_masses.npy
+++ b/test_composition/test_calculate_cell_masses.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa96124bba18724c27bcb603e3a2d8805da5c86a106e19b0672f2c4c23fb4fdb
+size 288

--- a/test_composition/test_calculate_elemental_cell_masses.npy
+++ b/test_composition/test_calculate_elemental_cell_masses.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d1cee4e664d774d49cd0fb7472607ede0e14b3c0a653416c340569979970dc6
+size 1088

--- a/test_composition/test_calculate_mass_fraction_at_time__time_explosion0__.h5
+++ b/test_composition/test_calculate_mass_fraction_at_time__time_explosion0__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3747e210265004e9828861c77f6be1462fae32ec60a4184b8ce4075b2100188
+size 7048

--- a/test_composition/test_calculate_mass_fraction_at_time__time_explosion1__.h5
+++ b/test_composition/test_calculate_mass_fraction_at_time__time_explosion1__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3747e210265004e9828861c77f6be1462fae32ec60a4184b8ce4075b2100188
+size 7048

--- a/test_composition/test_elemental_mass_fraction.h5
+++ b/test_composition/test_elemental_mass_fraction.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3747e210265004e9828861c77f6be1462fae32ec60a4184b8ce4075b2100188
+size 7048

--- a/test_composition/test_elemental_number_density.h5
+++ b/test_composition/test_elemental_number_density.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1cbbdb42a634499584ab1b37b54cf91e34ec1abcf65329d28efb987bd23703e
+size 7048

--- a/test_composition/test_elemental_number_density.npy
+++ b/test_composition/test_elemental_number_density.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9903acaeea88e7642e9820968f19d2c30dabf7aeb913e939bc23dc2f27be854
+size 152


### PR DESCRIPTION
I've added the regression data for the composition tests. This is related to the PR (https://github.com/tardis-sn/tardis/pull/2944/files) 

However I had to add the folder and the files in the root. If I add them in the tardis/model/matter the pytest isnt picking these files. Would be very glad if I could get some review on this. 

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Linked my forked repo to the tardis regression data argument while running tests
- [] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
