### PR TITLE
add new regression data for the high energy part

### DIFF
--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__direction__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__direction__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e3a48dc9cac671b83cd9935c017ee2b8dc530839e3b2d3eadcb748b562bf3c
+size 7200128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_cmf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_cmf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eb0577eec0d6424162b3eee722115ef0453c9c5ca96cc124d83e6ca31251f00
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_rf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_rf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f931dad77d4ae0f4bbad95555764a2723d7b5a3a84036a9cac007af66d1e9ed6
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__location__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__location__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71a83f11709c79ee00e424644312810bddbdb2e40beb7b469959c9d70c95a6ee
+size 7200128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_cmf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_cmf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0daf4793a49f5522f308623a531a6250323ea8ef3f82766535ca65bd6a14ae1d
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_rf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_rf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a197eac256d7af93657b0ad9915bb04ef103a20f39c6f2ee7ffd74062bd92a
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__shell__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__shell__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6673db1038242378bc53463f28f4aecbf637eebc2d2faabd9c1f93f67a604b0
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__status__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__status__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c692c5403335b8bf5cd71767783dbb86cbab7d23725ad4fc59c4509f7c4cf2
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_index__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_index__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bc061da0c88b5de708be4479eea3bf6c8b77192274fd35da6bfa479a44b0d35
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_start__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_start__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d25ccea937501ffd6e7f76be018199925bc49fb80448f334aa04e2eeb246451
+size 2400128


### PR DESCRIPTION
This pull request adds several new `.npy` files containing test data for gamma-ray packet properties in the `tardis/energy_input/tests/test_gamma_ray_packet_source_minimal` directory. These files appear to provide data for various attributes of gamma-ray packets, such as direction, energy, location, and status, among others.

### Test Data Additions:

* [`test_gamma_ray_packet_properties__direction__.npy`](diffhunk://#diff-72889602fb11646a40352c648be3fff8e8aa32e2c52ba5193c0d7d618d361486R1-R3): Includes data related to the direction of gamma-ray packets.
* `test_gamma_ray_packet_properties__energy_cmf__.npy` and `test_gamma_ray_packet_properties__energy_rf__.npy`: Provide energy data in the co-moving frame and rest frame, respectively. [[1]](diffhunk://#diff-1c83233e838e096ddb3fa70178d3bbef6ea76e60111c2da2702b1254a4e0858eR1-R3) [[2]](diffhunk://#diff-76d2331843c157967a7045ed635cfb9b9d08bdaee22631e18c7e25da7dde64d1R1-R3)
* [`test_gamma_ray_packet_properties__location__.npy`](diffhunk://#diff-bdadd55e131fd1d9dd23dff5cbd15e2621b36390929033ae78fcfeecd48a253dR1-R3): Contains location data for gamma-ray packets.
* [`test_gamma_ray_packet_properties__status__.npy`](diffhunk://#diff-a605ba412e7576cd618748f84698c58a218ab66325f7e8112b63dacce7413ea3R1-R3): Tracks the status of gamma-ray packets.