### PR TITLE
High energy/add regression data addon

### DIFF
--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__direction__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__direction__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e3a48dc9cac671b83cd9935c017ee2b8dc530839e3b2d3eadcb748b562bf3c
+size 7200128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_cmf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_cmf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eb0577eec0d6424162b3eee722115ef0453c9c5ca96cc124d83e6ca31251f00
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_rf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__energy_rf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f931dad77d4ae0f4bbad95555764a2723d7b5a3a84036a9cac007af66d1e9ed6
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__location__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__location__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71a83f11709c79ee00e424644312810bddbdb2e40beb7b469959c9d70c95a6ee
+size 7200128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_cmf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_cmf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0daf4793a49f5522f308623a531a6250323ea8ef3f82766535ca65bd6a14ae1d
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_rf__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__nu_rf__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a197eac256d7af93657b0ad9915bb04ef103a20f39c6f2ee7ffd74062bd92a
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__shell__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__shell__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6673db1038242378bc53463f28f4aecbf637eebc2d2faabd9c1f93f67a604b0
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__status__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__status__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61c692c5403335b8bf5cd71767783dbb86cbab7d23725ad4fc59c4509f7c4cf2
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_index__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_index__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bc061da0c88b5de708be4479eea3bf6c8b77192274fd35da6bfa479a44b0d35
+size 2400128

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_start__.npy
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal/test_gamma_ray_packet_properties__time_start__.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d25ccea937501ffd6e7f76be018199925bc49fb80448f334aa04e2eeb246451
+size 2400128

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec7370885175d710599f45a3dfd016479993d40291504f6c1b8d8fe7abad3116
-size 175320
+oid sha256:989e9b0ab7a1a3df1602d1ae459745ea311af0b55847f2906ed850d9f19cc4ed
+size 175240

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec7370885175d710599f45a3dfd016479993d40291504f6c1b8d8fe7abad3116
+size 175320

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy_cosi__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy_cosi__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a32efa51c252da501281c9a0eeeb578ac055fdf4700a1b1807ed8f5762b9a00b
+size 175320

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy_cosi__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__escape_energy_cosi__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a32efa51c252da501281c9a0eeeb578ac055fdf4700a1b1807ed8f5762b9a00b
-size 175320
+oid sha256:153860f4deeb4c4e31cfbb7e74439559b0e15ac6ffb6a538bcc34b5fa5803307
+size 175240

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__gamma_ray_deposited_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__gamma_ray_deposited_energy__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b82750aed0d7d9024c9a74d828f7cadb446dad0382a60373bc0e6b2425b0dec4
-size 14880
+oid sha256:fd667f71006ec6ef301d8b32b949afba3b577fa5bc71a2e0631efbc3dd177d05
+size 14440

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__gamma_ray_deposited_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__gamma_ray_deposited_energy__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b82750aed0d7d9024c9a74d828f7cadb446dad0382a60373bc0e6b2425b0dec4
+size 14880

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__packets_escaped__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__packets_escaped__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02bc177625d51b0096bdfd23dd952c21f6cae4aa9d95262f3d5531f445f11061
-size 21607320
+oid sha256:0c39fff0d10caa73edb97d3359c2020df1f6745d87fec8c76a0341012e85021b
+size 21607240

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__packets_escaped__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__packets_escaped__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02bc177625d51b0096bdfd23dd952c21f6cae4aa9d95262f3d5531f445f11061
+size 21607320

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__positron_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__positron_energy__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80f3922b721d6d24ccf13873b9802182424d526ac03bcafd71a03aadc2c5f89b
-size 14880
+oid sha256:5b79e3679af4882fd8a9371c1671eda91b696fd8dbe9f70ff1408a1a26eae1f0
+size 14440

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__positron_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__positron_energy__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80f3922b721d6d24ccf13873b9802182424d526ac03bcafd71a03aadc2c5f89b
+size 14880

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__total_deposited_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__total_deposited_energy__.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8895188ce459705025ed3ffc50808b33df2889114497e9534ede2d0fb2dd1050
+size 14880

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__total_deposited_energy__.h5
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow/test_he_workflow_all_outputs_regression__total_deposited_energy__.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8895188ce459705025ed3ffc50808b33df2889114497e9534ede2d0fb2dd1050
-size 14880
+oid sha256:c9a4049f49ddf528aca9e693737ecb13ee6c181714c7854cd9f9397f95b273d5
+size 14440


### PR DESCRIPTION
@andrewfullard this is an update with an update to the seeding. It should still work with Anirban's version of the code. 
This pull request adds new test data files for validating gamma-ray packet properties and high-energy workflow outputs in the `tardis` module. The new files are primarily `.npy` and `.h5` files containing precomputed data for regression testing and analysis.

### Gamma-ray packet properties test data:
* Added `.npy` files for various gamma-ray packet properties, including direction, energy (CMF and RF), location, frequency (CMF and RF), shell, status, time index, and start time. These files will support minimal gamma-ray packet source testing. [[1]](diffhunk://#diff-72889602fb11646a40352c648be3fff8e8aa32e2c52ba5193c0d7d618d361486R1-R3) [[2]](diffhunk://#diff-1c83233e838e096ddb3fa70178d3bbef6ea76e60111c2da2702b1254a4e0858eR1-R3) [[3]](diffhunk://#diff-76d2331843c157967a7045ed635cfb9b9d08bdaee22631e18c7e25da7dde64d1R1-R3) [[4]](diffhunk://#diff-bdadd55e131fd1d9dd23dff5cbd15e2621b36390929033ae78fcfeecd48a253dR1-R3) [[5]](diffhunk://#diff-998b1040315eaf65bb58d34f3895819740fd02cdfcf88a4fb847d6982683266eR1-R3) [[6]](diffhunk://#diff-535da6c2df090a8b9a22e438fae0383addd3e5c9b0225410f1e48dd8c671a25aR1-R3) [[7]](diffhunk://#diff-928a91d37940cfc139cc88fe75a472e0fc9baf2c4f7e4b3959ce2c40c7bff394R1-R3) [[8]](diffhunk://#diff-a605ba412e7576cd618748f84698c58a218ab66325f7e8112b63dacce7413ea3R1-R3) [[9]](diffhunk://#diff-f69c87ddeee615d5ca0faed0f55ba04ebcc820634452357a9042bb9c006303e3R1-R3) [[10]](diffhunk://#diff-db4ea3bb2353f5039738f54aae305ba19d20df33d547eb6eab8cb55e25be4ff6R1-R3)

### High-energy workflow outputs test data:
* Added `.h5` files for regression testing of high-energy workflow outputs, including escape energy, escape energy cosine, gamma-ray deposited energy, packets escaped, positron energy, and total deposited energy. These files will help ensure consistency in workflow results. [[1]](diffhunk://#diff-36bfe2c283cf8127b204a63d6490f680ddc1990a0d80b22be8e50a65a18731a7R1-R3) [[2]](diffhunk://#diff-81c86e6a42f2b7fef370dbf871ec239ae63de68f0aadb28ddd94508332fbb4c5R1-R3) [[3]](diffhunk://#diff-fc3cc6c3e159512863c6060ac317b3fb4a998abcd46a679ad384973f5ce73339R1-R3) [[4]](diffhunk://#diff-cde26324efc3077abe3fe0a2a6aeaef52fb7dc0c7b11d3d092f5d44ec9b677e5R1-R3) [[5]](diffhunk://#diff-44c3e5db980245e8e43a225c35099c1c563c23e607ca60912301c386efd7fadeR1-R3) [[6]](diffhunk://#diff-981fc1953f7544cecb3b37d85f2ed7ebed1f4c3a591ea6027701d132eec36b03R1-R3)