### PR TITLE
add regression data for source function tests

### DIFF
--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_Jblue_lu.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_Jblue_lu.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b8ce5bc7251ef85a49aafcc38aa19601d10ab1d56017e18795c8d0de22fd438
+size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad396c4ac966d01244fdb75c2e3f624dedb7e02beb17b40c127f9f8d9880dec7
+oid sha256:d30f25a3fd217a01dd53cec9edcdb1055c73bc96cada5dc81d0eb1912c9932af
 size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d30f25a3fd217a01dd53cec9edcdb1055c73bc96cada5dc81d0eb1912c9932af
+oid sha256:ad396c4ac966d01244fdb75c2e3f624dedb7e02beb17b40c127f9f8d9880dec7
 size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_Jred_lu.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad396c4ac966d01244fdb75c2e3f624dedb7e02beb17b40c127f9f8d9880dec7
+size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcb5073d9b281d9812b18c0bfdf2ef4d87f8e955c584f4c006065231191f7716
+oid sha256:ad3fb826b72bd2f5546b5e8e5ce1c1ed0ee9ea1b948481d346f97cf23cfe352e
 size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad3fb826b72bd2f5546b5e8e5ce1c1ed0ee9ea1b948481d346f97cf23cfe352e
+oid sha256:bcb5073d9b281d9812b18c0bfdf2ef4d87f8e955c584f4c006065231191f7716
 size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_att_S_ul.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad3fb826b72bd2f5546b5e8e5ce1c1ed0ee9ea1b948481d346f97cf23cfe352e
+size 4675968

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6ed1d08959fad35511046f90e29fb080458c8f8dcec3f5a2cf38aeb9dba617d
+oid sha256:d7083e48cf83e525e9d4da1f6e0bf3fcc04ae099257c3311ac20f201ba9a1a2e
 size 557408

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7083e48cf83e525e9d4da1f6e0bf3fcc04ae099257c3311ac20f201ba9a1a2e
+size 557408

--- a/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
+++ b/tardis/spectrum/formal_integral/tests/test_source_function/test_e_dot_u.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7083e48cf83e525e9d4da1f6e0bf3fcc04ae099257c3311ac20f201ba9a1a2e
+oid sha256:f6ed1d08959fad35511046f90e29fb080458c8f8dcec3f5a2cf38aeb9dba617d
 size 557408


### PR DESCRIPTION
Adds the regression data needed to test the values computed with the SourceFunctionSolver in [Tardis PR #3177](https://github.com/tardis-sn/tardis/pull/3177).