### PR TITLE
Fix species list parsing test

### DIFF
--- a/tardis/visualization/tools/tests/test_liv_plot/test_liv_plotter/test_parse_species_list___species_list__.npy
+++ b/tardis/visualization/tools/tests/test_liv_plot/test_liv_plotter/test_parse_species_list___species_list__.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd52ca4083d6986070296d6cc048d599f0a127d6efc495c1b0c8b11ae671e3c1
-size 240
+oid sha256:9416983990f4b244b23e7f1c9dad56dab40d5ba66e7b453a8d7002252d9b256e
+size 352

--- a/tardis/visualization/tools/tests/test_liv_plot/test_liv_plotter/test_parse_species_list___species_mapped__.npy
+++ b/tardis/visualization/tools/tests/test_liv_plot/test_liv_plotter/test_parse_species_list___species_mapped__.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd52ca4083d6986070296d6cc048d599f0a127d6efc495c1b0c8b11ae671e3c1
-size 240
+oid sha256:9416983990f4b244b23e7f1c9dad56dab40d5ba66e7b453a8d7002252d9b256e
+size 352


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

LIV plotter used the old *100 method for handling species so 14, 1 = 1401. See https://github.com/tardis-sn/tardis/pull/3145