### PR TITLE
Copy regression data for opacity calculations to nonhomology mode tests

### DIFF
--- a/tardis/transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_beta_sobolevs.npy
+++ b/tardis/transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_beta_sobolevs.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94f824c037e22127b41446e8402194e61c177bf8404b86a5f859765f91f621e8
+size 4675968

--- a/tardis/transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_sobolev_line_opacity.h5
+++ b/tardis/transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_sobolev_line_opacity.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ab3b4b8590769cd1630b1263c1d3f1fb038f4fa4aa4d61430dbc992a797367f
+size 4876000


### PR DESCRIPTION
Copies regression data from

`opacities/tests/test_tau_sobolev/test_calculate__beta_sobolevs.npy` -> `transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_beta_sobolevs.npy`
`opacities/tests/test_tau_sobolev/test_calculate_sobolev_line_opacity.h5` -> `transport/montecarlo/tests/test_nonhomologous/test_nonhomologous_calculate_sobolev_line_opacity.h5`

for nonhomology mode tests. Tests pass.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)
