### PR TITLE
add regdata for new tests

### DIFF
--- a/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_absorbing_probability_matrix_regression.npy
+++ b/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_absorbing_probability_matrix_regression.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fe93ac89b0f622aee7e43e938be5c84ee2dbb7920b3f7a84cce1665a244451d
+size 41088

--- a/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_deactivating_metadata_regression.h5
+++ b/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_deactivating_metadata_regression.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7709ac8b448e30724bdb3499f565035dd71dac56fd298e61e6b59f103ecb87c9
+size 1100008

--- a/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_transition_metadata_regression.h5
+++ b/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_transition_metadata_regression.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b725caba9d5d7efe1606ae333a10c7a3ced3b8709a971dafed1adba70b64c6ce
+size 1286168

--- a/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_transition_probabilities_regression.h5
+++ b/tardis/opacities/macro_atom/tests/test_continuum_macroatom/test_continuum_macro_atom_solver/test_transition_probabilities_regression.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:252547dcafc55dec46f85e093e61113cb6601639ad791f202b25cab5554e4522
+size 2248968

--- a/tardis/workflows/tests/test_iip_workflow/test_solve_montecarlo.npy
+++ b/tardis/workflows/tests/test_iip_workflow/test_solve_montecarlo.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2146248f79bd7bf9b575f4f130c990ddc3b08d4cb18fa9d567e3050787bd9bb
+size 80128


### PR DESCRIPTION
Adding regression data for simple iip workflow montecarlo run, and also data for the continuum macro atom. 