### PR TITLE
IIP Test data regenerated from tardis master branch

### DIFF
--- a/tardis/workflows/tests/test_iip_workflow/test_iip_plasma_after_mc.h5
+++ b/tardis/workflows/tests/test_iip_workflow/test_iip_plasma_after_mc.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d28fd8b25f19f40dcc4c822c97dd2e28575b203fbebabf636820a8d706eb2ad3
-size 1453814
+oid sha256:b895f8591b596897c11ea1463c9a0d0eae53087094e63fd7d879d916268ad821
+size 1465078

--- a/tardis/workflows/tests/test_iip_workflow/test_thermal_balance_solver.h5
+++ b/tardis/workflows/tests/test_iip_workflow/test_thermal_balance_solver.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:008936aa8d79904d2b499fec6e3e9a8816ef85f671e49b29cf97deda2ae61ab2
-size 1467602
+oid sha256:9000732241f6489e9ff5c9d3243c57cc1561c90911eb71a9c8a0de181e817c73
+size 1480914

--- a/tardis/workflows/tests/test_iip_workflow/test_type_iip_workflow_initial_plasma_regression.h5
+++ b/tardis/workflows/tests/test_iip_workflow/test_type_iip_workflow_initial_plasma_regression.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0bafde88255e07f9e4c31a369fef552f7d485a76b2824cd6a43f3dd73af5675
-size 3015436
+oid sha256:1cc0954e5c0fd05b6f230319d60e857d377d81f8c36ed042abae5c1f814b5572
+size 4080396


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

The tests for https://github.com/tardis-sn/tardis/pull/3624 were generated from that PR. They didn't have to be and probably should not have been. This regenerates them on Linux (Moria) from the tardis master branch.

Note that there are no tests on master that actually use this data. The tests are located in https://github.com/tardis-sn/tardis/pull/3651

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
