### PR TITLE
Remove excess input to allow workflow trigger to pass

### DIFF
--- a/.github/workflows/trigger-lfs-cache.yml
+++ b/.github/workflows/trigger-lfs-cache.yml
@@ -25,8 +25,7 @@ jobs:
             -d '{
               "ref": "master",
               "inputs": {
-                "atom-data-sparse": "false",
-                "allow_lfs_pull": "true"
+                "atom-data-sparse": "false"
               }
             }' 
       - name: Trigger LFS Cache Workflow Atom Data Sparse
@@ -40,7 +39,6 @@ jobs:
           -d '{
             "ref": "master",
             "inputs": {
-              "atom-data-sparse": "true",
-              "allow_lfs_pull": "true"
+              "atom-data-sparse": "true"
             }
           }' 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

The current LFS cache update workflow doesn't work right now because of the removal of the allow-lfs-pull option. This removes that old option.